### PR TITLE
Introduce intentional test failure

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -21,5 +21,10 @@
       <option name="name" value="Google" />
       <option name="url" value="https://dl.google.com/dl/android/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="MavenRepo" />
+      <option name="name" value="MavenRepo" />
+      <option name="url" value="https://repo.maven.apache.org/maven2/" />
+    </remote-repository>
   </component>
 </project>

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="true" project-jdk-name="1.8" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/androidTest/java/io/bitrise/sample/android/instrumentation/ExampleInstrumentedTest.kt
+++ b/app/src/androidTest/java/io/bitrise/sample/android/instrumentation/ExampleInstrumentedTest.kt
@@ -17,6 +17,18 @@ import org.junit.Assert.*
 class ExampleInstrumentedTest {
     @Test
     fun useAppContext() {
+        // When running tests via the `adb` utility, it is possible to pass additional arguments
+        // that are then usable within the test itself.
+        //
+        // This test includes an option to pass an argument to explicitly fail the test, which is
+        // useful to verify that Steps handle test failures correctly.
+        //
+        // See the `adb` documentation for more information: https://developer.android.com/studio/command-line/adb#am
+        val extraArguments = InstrumentationRegistry.getArguments()
+        if (extraArguments.getString("FAIL_UNIT_TEST") == "true") {
+            fail("Failing test due to `FAIL_UNIT_TEST` being set to `true`")
+        }
+
         // Context of the app under test.
         val appContext = InstrumentationRegistry.getInstrumentation().targetContext
         assertEquals("io.bitrise.sample.android", appContext.packageName)

--- a/app/src/androidTest/java/io/bitrise/sample/android/ui/ExampleUiTest.kt
+++ b/app/src/androidTest/java/io/bitrise/sample/android/ui/ExampleUiTest.kt
@@ -7,7 +7,9 @@ import androidx.test.espresso.matcher.ViewMatchers.withText
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import androidx.test.platform.app.InstrumentationRegistry
 import io.bitrise.sample.android.MainActivity
+import org.junit.Assert.fail
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -21,6 +23,17 @@ class HelloWorldEspressoTest {
 
     @Test
     fun helloWorldIsVisible() {
+        // When running tests via the `adb` utility, it is possible to pass additional arguments
+        // that are then usable within the test itself.
+        //
+        // This test includes an option to pass an argument to explicitly fail the test, which is
+        // useful to verify that Steps handle test failures correctly.
+        //
+        // See the `adb` documentation for more information: https://developer.android.com/studio/command-line/adb#am
+        val extraArguments = InstrumentationRegistry.getArguments()
+        if (extraArguments.getString("FAIL_UI_TEST") == "true") {
+            fail("Failing test due to `FAIL_UI_TEST` being set to `true`")
+        }
         onView(withText("Hello World!")).check(matches(isDisplayed()))
     }
 }


### PR DESCRIPTION
I'm developing a new Step (https://github.com/bitrise-steplib/bitrise-step-android-instrumented-test/pull/1) for running instrumented tests on pre-built APKs, and using this sample app as a test harness.

One thing I need to test is that the Step fails as expected if one of the instrumented tests fail. The changes in this PR follow a similar pattern we use to do the same thing in iOS tests that we need to fail.

I don't believe the changes here will effect the normal run of the tests. My Step also includes a test that does not pass these values, and it runs normally.

What do you think of this change?

## Changes

- Adds a check for additional arguments passed to the test.
- Some changes in the `.idea` directory that were automatically made by Android Studio. I don't know what they changes do, so let me know if you'd like me to revert them.